### PR TITLE
add gcc 9.3 for better c++17 support; remove deprecated "arch_build" …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.3] 2021.Q1
+
+- use cmake conan package with version >=3.15.0 for ninja native build
+- add gcc 9.3 to builder image to have better c++17 support
+- removed deprecated "arch_build" and "os_build" from conan profiles
 - add ssh e.g. for conan builds which use git via ssh to get sources
 
 ## [0.1.2] 2021.Q1

--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -47,29 +47,41 @@ COPY --from=codecheckerbuilder /codechecker/web/requirements_py /tmp/requirement
 COPY --from=codecheckerbuilder /codechecker/web/requirements.txt /tmp/requirements_py
 
 RUN apt-get update &&  \
-    apt-get install -y --no-install-recommends \
-    apt-utils \
-    autoconf \
-    automake \
-    build-essential \
-    clang \
-    clang-tidy \
-    cmake \
-    crossbuild-essential-arm64 \
-    crossbuild-essential-armhf \
-    doxygen \
-    gdb-multiarch \
-    git \
-    gosu \
-    graphviz \
-    libtool \
-    openssh-client \
-    python3-dev \
-    python3-pip \
-    wget \
-    xutils-dev \
-    && \
-    apt-get clean
+        apt-get install -y --no-install-recommends \
+        apt-utils \
+        autoconf \
+        automake \
+        build-essential \
+        clang \
+        clang-tidy \
+        cmake \
+        crossbuild-essential-arm64 \
+        crossbuild-essential-armhf \
+        doxygen \
+        gdb-multiarch \
+        git \
+        gosu \
+        graphviz \
+        libtool \
+        openssh-client \
+        python3-dev \
+        python3-pip \
+        wget \
+        xutils-dev \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# install explicitly gcc 9 from testing to have a c++17 compliant compiler
+RUN echo 'deb http://deb.debian.org/debian testing main' >> /etc/apt/sources.list
+RUN apt-get update &&  \
+        apt-get install -y --no-install-recommends \
+        gcc-9 \
+        g++-9 \
+        gcc-9-aarch64-linux-gnu \
+        g++-9-aarch64-linux-gnu \
+        gcc-9-arm-linux-gnueabihf \
+        g++-9-arm-linux-gnueabihf \
+    && apt-get autoremove && apt-get clean && rm -rf /var/lib/apt/lists/*
+
 RUN pip3 install setuptools wheel \
     && pip3 install conan \
     && pip3 install -r /tmp/requirements_py/requirements.txt

--- a/builder/conan.aarch64.profile
+++ b/builder/conan.aarch64.profile
@@ -1,16 +1,15 @@
 toolchain=/
 target_host=aarch64-linux-gnu
-cc_compiler=gcc
-cxx_compiler=g++
+cc_compiler=gcc-9
+cxx_compiler=g++-9
 
 [settings]
 os=Linux
-os_build=Linux
 arch=armv8
-arch_build=x86_64
 compiler=gcc
-compiler.version=8
+compiler.version=9.3
 compiler.libcxx=libstdc++11
+compiler.cppstd=17
 build_type=Release
 [options]
 [build_requires]

--- a/builder/conan.armv7hf.profile
+++ b/builder/conan.armv7hf.profile
@@ -1,16 +1,15 @@
 toolchain=/
 target_host=arm-linux-gnueabihf
-cc_compiler=gcc
-cxx_compiler=g++
+cc_compiler=gcc-9
+cxx_compiler=g++-9
 
 [settings]
 os=Linux
-os_build=Linux
 arch=armv7hf
-arch_build=x86_64
 compiler=gcc
-compiler.version=8
+compiler.version=9.3
 compiler.libcxx=libstdc++11
+compiler.cppstd=17
 build_type=Release
 [options]
 [build_requires]

--- a/builder/conan.x86_64.profile
+++ b/builder/conan.x86_64.profile
@@ -1,19 +1,19 @@
 toolchain=/
 target_host=x86_64-linux-gnu
-cc_compiler=gcc
-cxx_compiler=g++
+cc_compiler=gcc-9
+cxx_compiler=g++-9
 
 [settings]
 os=Linux
-os_build=Linux
 arch=x86_64
-arch_build=x86_64
 compiler=gcc
-compiler.version=8
+compiler.version=9.3
 compiler.libcxx=libstdc++11
+compiler.cppstd=17
 build_type=Release
 [options]
 [build_requires]
+ninja/1.10.*: cmake/[>=3.15.0]
 [env]
 CONAN_CMAKE_FIND_ROOT_PATH=$toolchain
 CHOST=$target_host


### PR DESCRIPTION
…and "os_build" from conan profiles; use cmake conan package for ninja native build